### PR TITLE
Fix null terminator for tags and strings

### DIFF
--- a/src/ZoscMessage.cpp
+++ b/src/ZoscMessage.cpp
@@ -76,8 +76,9 @@ std::string ZoscMessage::serialize() const {
 			oss.put('t'); // Time tag type
 		}
 	}
+	oss.put('\0');
 	// Align memory with '\0' padding
-	padding = ((4 - ((_arguments.size() + 1) % 4)) % 4);
+	padding = ((4 - ((_arguments.size() + 2) % 4)) % 4);
 	oss.write("\0\0\0", padding);
 
 	// Serialize the arguments
@@ -99,7 +100,8 @@ std::string ZoscMessage::serialize() const {
 			const std::string &value = std::get<std::string>(arg);
 			oss << value;
 			// Align memory with '\0' padding
-			padding = ((4 - (value.size() % 4)) % 4);
+			oss.put('\0');
+			padding = ((4 - ((value.size() + 1) % 4)) % 4);
 			oss.write("\0\0\0", padding);
 			// Serialize blob arg
 		} else if (std::holds_alternative<std::vector<uint8_t>>(arg)) {


### PR DESCRIPTION
Hello, first of all, thank you for your work. Your code was very helpful for a small project of mine.

I seem to have encountered an issue with your code:

The tag section and string arguments always require a null terminator. When padding is added, it only works by accident because the padding acts as the null terminator.

My patch forces a null terminator to be present in all cases.

Test exemple :

    ZoscMessage msg_set("/n_set");
    msg_set.addArgument(std::string("freq")); // no null terminator before patch
    msg_set.addArgument(45);
    sender.sendMessage(msg_set);